### PR TITLE
feature: install pydantic v2, import pydantic v1 for now

### DIFF
--- a/graphql_query/types.py
+++ b/graphql_query/types.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import Any, List, Optional, Union
 
 from jinja2 import Environment, FileSystemLoader, Template
-from pydantic import BaseModel
-from pydantic import Field as PydanticField
+from pydantic.v1 import BaseModel
+from pydantic.v1 import Field as PydanticField
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "pydantic>=1.10, <1.11",
+    "pydantic>=2",
     "jinja2>=3.1, <3.2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
<!--
  Thanks for making a pull request! 
  
  Before submitting, please read our contributing guidelines:
  [https://github.com/graphql/graphql.github.io/blob/source/CONTRIBUTING.md](https://github.com/denisart/graphql-query/blob/master/CONTRIBUTING.md)

-->

## Description

I'm building a project that I migrated to Pydantic v2 for my own models, but I would like to use graphql-query. Because graphql-query relies on Pydantic v1, this is currently impossible.

This allows users of Pydantic v2 to continue to use graphql-query by installing Pydantic 2 but importing v1, as seen in the [migration guide](https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features) for Pydantic. I don't think it would be too hard to upgrade this library to Pydantic v2, but this is a first step in that direction.

<!-- Write a brief description of the changes introduced by this PR -->
