### PR TITLE
support for simple str list ['123', '456'] and keep backward compatible

### DIFF
--- a/graphql_query/types.py
+++ b/graphql_query/types.py
@@ -217,7 +217,20 @@ class Argument(_GraphQL2PythonQuery):
 
     @staticmethod
     def _render_for_list_str(name: str, value: List[str]) -> str:
-        return _template_key_values.render(name=name, values=value)
+        clean_list = []
+        for item in value:
+            result = item.replace('"', '').split(',')
+            if type(result) is list:
+                trimmed_result = [i.strip() for i in result]
+                clean_list.extend(trimmed_result)
+            else:
+                clean_list.append(result)
+
+        return _template_key_values.render(name=name, values=[f"\"{v.replace('"', '')}\"" for v in clean_list])
+
+    @staticmethod
+    def _render_for_list_int(name: str, value: List[str]) -> str:
+        return _template_key_values.render(name=name, values=[str(v) for v in value])
 
     @staticmethod
     def _render_for_list_bool(name: str, value: List[bool]) -> str:
@@ -277,7 +290,7 @@ class Argument(_GraphQL2PythonQuery):
                 return self._render_for_list_float(self.name, self.value)
 
             if self._check_is_list_of_int(self.value):
-                return self._render_for_list_str(self.name, [str(v) for v in self.value])
+                return self._render_for_list_int(self.name, self.value)
 
             if self._check_is_list_of_arguments(self.value):
                 return self._render_for_list_argument(self.name, self.value)

--- a/graphql_query/types.py
+++ b/graphql_query/types.py
@@ -220,7 +220,7 @@ class Argument(_GraphQL2PythonQuery):
         clean_list = []
         for item in value:
             result = item.replace('"', '').split(',')
-            if type(result) is list:
+            if isinstance(result, list):
                 trimmed_result = [i.strip() for i in result]
                 clean_list.extend(trimmed_result)
             else:

--- a/graphql_query/types.py
+++ b/graphql_query/types.py
@@ -229,7 +229,7 @@ class Argument(_GraphQL2PythonQuery):
         return _template_key_values.render(name=name, values=[f"\"{v.replace('"', '')}\"" for v in clean_list])
 
     @staticmethod
-    def _render_for_list_int(name: str, value: List[str]) -> str:
+    def _render_for_list_int(name: str, value: List[int]) -> str:
         return _template_key_values.render(name=name, values=[str(v) for v in value])
 
     @staticmethod

--- a/graphql_query/types.py
+++ b/graphql_query/types.py
@@ -226,7 +226,7 @@ class Argument(_GraphQL2PythonQuery):
             else:
                 clean_list.append(result)
 
-        return _template_key_values.render(name=name, values=[f"\"{v.replace('"', '')}\"" for v in clean_list])
+        return _template_key_values.render(name=name, values=[f'''\"{v.replace('"', '')}\"''' for v in clean_list])
 
     @staticmethod
     def _render_for_list_int(name: str, value: List[int]) -> str:

--- a/tests/test_argument/test_argument.py
+++ b/tests/test_argument/test_argument.py
@@ -26,10 +26,21 @@ def test_value_is_float():
     assert Argument(name="some", value=0.2).render() == 'some: 0.2'
 
 
-def test_value_is_list_str():
+def test_value_is_list_str_with_backward_compatible_workarounds():
     assert Argument(name="someListArgument", value=['"123"']).render() == 'someListArgument: ["123"]'
     assert Argument(name="someListArgument", value=[]).render() == 'someListArgument: []'
     assert Argument(name="someListArgument", value=['"123", "456"']).render() == 'someListArgument: ["123", "456"]'
+
+
+def test_value_is_list_str():
+    assert Argument(name="someListArgument", value=["123", "456"]).render() == 'someListArgument: ["123", "456"]'
+    assert Argument(name="someListArgument",
+                    value=["hello", "world"]).render() == 'someListArgument: ["hello", "world"]'
+
+
+def test_value_is_list_str_with_apostrophe():
+    assert Argument(name="someListArgument",
+                    value=["you'r", "isn't"]).render() == 'someListArgument: ["you\'r", "isn\'t"]'
 
 
 def test_value_is_list_int():

--- a/tests/test_argument/test_argument.py
+++ b/tests/test_argument/test_argument.py
@@ -6,58 +6,60 @@ from graphql_query import Argument, Variable
 def test_value_is_str():
     assert Argument(name="arg1", value="VALUE1").render() == "arg1: VALUE1"
     assert Argument(name="id", value='"1000"').render() == 'id: "1000"'
-    assert Argument(name="length", value='911').render() == 'length: 911'
+    assert Argument(name="length", value="911").render() == "length: 911"
     assert Argument(name="unit", value="null").render() == "unit: null"
 
 
 def test_value_is_int():
-    assert Argument(name="length", value=911).render() == 'length: 911'
-    assert Argument(name="length", value=0).render() == 'length: 0'
-    assert Argument(name="length", value=-1).render() == 'length: -1'
+    assert Argument(name="length", value=911).render() == "length: 911"
+    assert Argument(name="length", value=0).render() == "length: 0"
+    assert Argument(name="length", value=-1).render() == "length: -1"
 
 
 def test_value_is_bool():
-    assert Argument(name="some", value=True).render() == 'some: true'
-    assert Argument(name="some", value=False).render() == 'some: false'
+    assert Argument(name="some", value=True).render() == "some: true"
+    assert Argument(name="some", value=False).render() == "some: false"
 
 
 def test_value_is_float():
-    assert Argument(name="some", value=1.0).render() == 'some: 1.0'
-    assert Argument(name="some", value=0.2).render() == 'some: 0.2'
+    assert Argument(name="some", value=1.0).render() == "some: 1.0"
+    assert Argument(name="some", value=0.2).render() == "some: 0.2"
 
 
 def test_value_is_list_str_with_backward_compatible_workarounds():
     assert Argument(name="someListArgument", value=['"123"']).render() == 'someListArgument: ["123"]'
-    assert Argument(name="someListArgument", value=[]).render() == 'someListArgument: []'
+    assert Argument(name="someListArgument", value=[]).render() == "someListArgument: []"
     assert Argument(name="someListArgument", value=['"123", "456"']).render() == 'someListArgument: ["123", "456"]'
 
 
 def test_value_is_list_str():
     assert Argument(name="someListArgument", value=["123", "456"]).render() == 'someListArgument: ["123", "456"]'
-    assert Argument(name="someListArgument",
-                    value=["hello", "world"]).render() == 'someListArgument: ["hello", "world"]'
+    assert (
+        Argument(name="someListArgument", value=["hello", "world"]).render() == 'someListArgument: ["hello", "world"]'
+    )
 
 
 def test_value_is_list_str_with_apostrophe():
-    assert Argument(name="someListArgument",
-                    value=["you'r", "isn't"]).render() == 'someListArgument: ["you\'r", "isn\'t"]'
+    assert (
+        Argument(name="someListArgument", value=["you'r", "isn't"]).render() == 'someListArgument: ["you\'r", "isn\'t"]'
+    )
 
 
 def test_value_is_list_int():
-    assert Argument(name="someListArgument", value=[123]).render() == 'someListArgument: [123]'
-    assert Argument(name="someListArgument", value=[]).render() == 'someListArgument: []'
-    assert Argument(name="someListArgument", value=[123, 456]).render() == 'someListArgument: [123, 456]'
+    assert Argument(name="someListArgument", value=[123]).render() == "someListArgument: [123]"
+    assert Argument(name="someListArgument", value=[]).render() == "someListArgument: []"
+    assert Argument(name="someListArgument", value=[123, 456]).render() == "someListArgument: [123, 456]"
 
 
 def test_value_is_list_bool():
-    assert Argument(name="someListArgument", value=[True, False]).render() == 'someListArgument: [true, false]'
-    assert Argument(name="someListArgument", value=[True]).render() == 'someListArgument: [true]'
-    assert Argument(name="someListArgument", value=[False]).render() == 'someListArgument: [false]'
+    assert Argument(name="someListArgument", value=[True, False]).render() == "someListArgument: [true, false]"
+    assert Argument(name="someListArgument", value=[True]).render() == "someListArgument: [true]"
+    assert Argument(name="someListArgument", value=[False]).render() == "someListArgument: [false]"
 
 
 def test_value_is_list_float():
-    assert Argument(name="someListArgument", value=[1.0, 0.2]).render() == 'someListArgument: [1.0, 0.2]'
-    assert Argument(name="someListArgument", value=[42.0]).render() == 'someListArgument: [42.0]'
+    assert Argument(name="someListArgument", value=[1.0, 0.2]).render() == "someListArgument: [1.0, 0.2]"
+    assert Argument(name="someListArgument", value=[42.0]).render() == "someListArgument: [42.0]"
 
 
 @pytest.mark.parametrize(
@@ -73,7 +75,7 @@ def test_value_is_list_float():
             Argument(name="field", value=['"value1"', '"value2"']),
             'filter: {\n  field: ["value1", "value2"]\n}',
         ),
-        ("filter", Argument(name="field", value=Variable(name="var", type="Variable")), 'filter: {\n  field: $var\n}'),
+        ("filter", Argument(name="field", value=Variable(name="var", type="Variable")), "filter: {\n  field: $var\n}"),
     ],
 )
 def test_value_is_argument(name: str, value: Argument, result: str):
@@ -84,7 +86,7 @@ def test_value_is_argument(name: str, value: Argument, result: str):
 def test_value_is_variable():
     var = Variable(name="var", type="Variable")
     arg = Argument(name="field", value=var)
-    assert arg.render() == 'field: $var'
+    assert arg.render() == "field: $var"
 
 
 def test_value_is_list_of_args():


### PR DESCRIPTION
Closes #21 

## Description
I've updated  `_render_for_list_str` to handle simple list of `str` like ['123', '345'], ['hello', 'world'].
I've made it backward compatible to support all the workarounds that I've found in the tests and also added a few new tests.
All the tests seems to pass.

Also, thanks for working on this project!

